### PR TITLE
fix - requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.16.4
 matplotlib==2.0.0
 pandas==0.19.2
 scikit-learn==0.18.1


### PR DESCRIPTION
Specify numpy version to 1.16.4 since the default version installed as the dependency of matplotlib  ver 2.0.0 (installs numpy ver 1.18.4) no longer works with pandas ver 0.19.2